### PR TITLE
tool: Create input pick files from ObsPy Catalog

### DIFF
--- a/SetupRun/README.md
+++ b/SetupRun/README.md
@@ -1,0 +1,24 @@
+# Setting up for an FMTomo run
+The FMTomo documentation covers all aspects of the package, including descriptions of all the required input files and their formats. It should always be used as a first point of reference.
+
+General process
+===============
+1. Create a new run directory by making a copy of the base run directory and giving it a name
+2. Create the input pick files and a station file using the ``obspy2fmtomo`` notebook
+3. Create a starting (1-D) velocity model - make a copy of the ``ak135.vel`` file and add any local layers.
+4. Set up the propagation and inversion grids by editing the ``grid3dg.in`` file.
+5. Specify the input source, receiver, pick files in the ``obsdata.in`` file.
+
+Input files
+===========
+The input files are fairly self-explanatory, but here are some short notes:
+
+`frechgen.in` - controls inversion of subsets of, e.g., source locations, or velocity layers.
+
+`mode_set.in` - controls general run parameters. Each option is described in detail in the default file.
+
+`residuals.in` - just points at data files. Don't change.
+
+`scorrect.in` - points to input files required for source corrections.
+
+`tomo3d.in` - controls inversion. Each option is described in detail in the default file.

--- a/SetupRun/obspy2fmtomo.ipynb
+++ b/SetupRun/obspy2fmtomo.ipynb
@@ -1,0 +1,559 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generating input for FMTOMO from an ObsPy catalogue\n",
+    "\n",
+    "We provide here a small set of utilities that produce the required inputs for [FMTomo](http://rses.anu.edu.au/~nick/fmtomo.html) from an [ObsPy Catalog](https://docs.obspy.org/packages/autogen/obspy.core.event.Catalog.html) - namely:\n",
+    "\n",
+    "1. A collection of files containing phase pick information for each event;\n",
+    "2. and a single control file that details all available picks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "code_folding": [
+     0
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# --- Imports ---\n",
+    "import pathlib\n",
+    "\n",
+    "import numpy as np\n",
+    "import obspy\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pick files\n",
+    "\n",
+    "***File format***\n",
+    "\n",
+    "The first line should contain the total number of picks, followed by rows containing:\n",
+    "\n",
+    "| latitude | longitude | depth | traveltime | error |\n",
+    "| --- | --- | --- | --- | --- |\n",
+    "| ... | ... | ... | ... | ... |\n",
+    "\n",
+    "for each pick."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Control file\n",
+    "If you do not want to simultaneously invert for earthquake hypocentres as well as the velocity model, we can treat the receivers as pseudo-sources. This allows us to greatly speed up the inversion as we only need to compute the forward problem for each station (order of 10s), rather than for each earthquake (order of 1000s).\n",
+    "\n",
+    "***File format***\n",
+    "\n",
+    "The first line should contain the total number of sources, followed by a source line:\n",
+    "\n",
+    "| latitude | longitude | depth |\n",
+    "| --- | --- | --- |\n",
+    "\n",
+    "Then a line containing the total of picks for that source, followed by the phase and total phase count so far:\n",
+    "\n",
+    "| phase | phase count |\n",
+    "| --- | --- |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "code_folding": [
+     0
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# --- Functions ---\n",
+    "def obspy2fmtomo(catalogue, stations, output_dir, phases):\n",
+    "    \"\"\"\n",
+    "    Generate input files for the FMTOMO software package from an ObsPy\n",
+    "    catalogue.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    catalogue : `obspy.Catalog` object\n",
+    "        Contains a list of `obspy.Event` objects, detailing origin times and\n",
+    "        phase picks.\n",
+    "    stations : `pandas.DataFrame` object\n",
+    "        DataFrame containing station information (latitude/longitude/elevation\n",
+    "        and a uid).\n",
+    "    output_dir : str\n",
+    "        Directory in which to save the output.\n",
+    "    phases : list of str\n",
+    "        List of phases to include in the output files.\n",
+    "\n",
+    "    \"\"\"\n",
+    "\n",
+    "    output_dir = pathlib.Path(output_dir)\n",
+    "    output_dir.mkdir(exist_ok=True, parents=True)\n",
+    "\n",
+    "    pick_cols = [\"olat\", \"olon\", \"odep\", \"ttime\", \"ttime_err\"]\n",
+    "    pick_dict = {}\n",
+    "    for i, station in stations.iterrows():\n",
+    "        stat = station[\"Name\"]\n",
+    "        print(f\"Creating pick file for {stat}...\")\n",
+    "\n",
+    "        # Create DataFrames to store all picks for each phase\n",
+    "        dfs = {}\n",
+    "        for phase in phases:\n",
+    "            dfs[phase] = pd.DataFrame(columns=pick_cols)\n",
+    "\n",
+    "        for event in catalogue:\n",
+    "            origin = event.preferred_origin()\n",
+    "            olat, olon, odep = origin.latitude, origin.longitude, origin.depth\n",
+    "            otime = origin.time\n",
+    "            for pick in event.picks:\n",
+    "                if pick.waveform_id.station_code == stat:\n",
+    "                    line = pd.DataFrame([float(olat), float(olon), float(odep),\n",
+    "                                         float(pick.time - otime),\n",
+    "                                         float(pick.time_errors.uncertainty)],\n",
+    "                                        index=pick_cols).T\n",
+    "                    phase = pick.phase_hint\n",
+    "                    if phase in phases:\n",
+    "                        dfs[phase] = pd.concat([dfs[phase], line])\n",
+    "\n",
+    "        for phase in phases:\n",
+    "            out = output_dir / \"picks\"\n",
+    "            out.mkdir(parents=True, exist_ok=True)\n",
+    "            outfile = out / f\"{stat}.{phase}pick\"\n",
+    "            out_df = dfs[phase]\n",
+    "            if out_df.empty:\n",
+    "                continue\n",
+    "            out_df = out_df.apply(pd.to_numeric)\n",
+    "            with outfile.open(\"w\") as f:\n",
+    "                print(f\"{len(out_df)}\", file=f)\n",
+    "                for i, pick in out_df.iterrows():\n",
+    "                    print((f\"{pick.olat:.4f} {pick.olon:.4f} \"\n",
+    "                           f\"{pick.odep/1000:.5f} {pick.ttime:.4f} \"\n",
+    "                           f\"{pick.ttime_err:.2f}\"), file=f)\n",
+    "\n",
+    "        anypicks = [dfs[phase].empty for pick in phases]\n",
+    "        if not np.all(anypicks):\n",
+    "            pick_dict[stat] = dfs\n",
+    "    print(\"Generation of pick files complete.\")\n",
+    "\n",
+    "    with (output_dir / \"pick.control\").open(\"w\") as f:\n",
+    "        print(f\"{len(pick_dict)}\", file=f)\n",
+    "        for key, value in pick_dict.items():\n",
+    "            station = stations[stations[\"Name\"] == key].iloc[0]\n",
+    "            stat = station[\"Name\"]\n",
+    "            print((f\"{station.Latitude:.4f} \"\n",
+    "                   f\"{station.Longitude:.4f} \"\n",
+    "                   f\"{station.Elevation:.4f}\"), file=f)\n",
+    "\n",
+    "            print(f\"{len(phases)}\", file=f)\n",
+    "            for phase in phases:\n",
+    "                print(f\"1 1 {stat}.{phase}pick\", file=f)\n",
+    "\n",
+    "    stat_df = pd.DataFrame(columns=[\"Name\", \"Latitude\", \"Longitude\", \"Elevation\"])\n",
+    "    for key in pick_dict.keys():\n",
+    "        stat_df = pd.concat([stat_df, stations[stations[\"Name\"] == key]])\n",
+    "\n",
+    "    stat_df.to_csv(str(output_dir / \"stations_file.txt\"), index=False)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating inputs\n",
+    "\n",
+    "The input files should be output to the `mkmodel` directory of your FMTomo run - set below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mkmodel = \"/path/to/mkmodel\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Station files\n",
+    "\n",
+    "You must provide a file containing an initial list of stations. A station file for use in FMTomo is produced from those for which there exist picks in the event catalogue."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stations = pd.read_csv(\"/path/to/station_file\")\n",
+    "\n",
+    "# Elevation must be in km and positive UP - apply any necessary corrections\n",
+    "# Metres -> Kilometres\n",
+    "# stations[\"Elevation\"] = stations[\"Elevation\"].apply(lambda x: x / 1000)\n",
+    "\n",
+    "# Positive-down -> Positive-up\n",
+    "# stations[\"Elevation\"] = stations[\"Elevation\"].apply(lambda x: x / -1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Reading in event catalogues"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Read events from .hyp file\n",
+    "\n",
+    "The .hyp file format extension is used for the outputs from NonLinLoc. ObsPy provide a parser that can read these files and build an ObsPy Catalog, which can then be parsed into the inputs for FMTomo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cat = obspy.read_events(\"/path/to/.hyp\")\n",
+    "cat = obspy.read_events(\"../input_files/askja_tim.loc.summary.hyp\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2430 Event(s) in Catalog:\n",
+      "2006-07-08T09:27:25.151600Z | +65.118,  -16.643\n",
+      "2006-07-14T02:50:04.544910Z | +65.034,  -16.696\n",
+      "...\n",
+      "2014-09-02T11:23:04.860740Z | +65.194,  -16.258\n",
+      "2014-09-02T15:29:19.528000Z | +65.081,  -16.450\n",
+      "To see all events call 'print(CatalogObject.__str__(print_all=True))'\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(cat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Read events from QuakeMigrate run\n",
+    "\n",
+    "QuakeMigrate provides a utility function that will read the outputs of a given run into an ObsPy Catalog, which can then be parsed into the inputs for FMTomo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import quakemigrate.export.to_obspy as obspy_catalog\n",
+    "\n",
+    "cat = obspy_catalog.read_quakemigrate(\"/path/to/run\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(cat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create inputs\n",
+    "\n",
+    "Note: Using the same output path for P and S (if run separately) will overwrite the `pick.control` file. Either make a copy or choose a different output directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating pick file for ARNA...\n",
+      "Creating pick file for ASK...\n",
+      "Creating pick file for BJK...\n",
+      "Creating pick file for BLAF...\n",
+      "Creating pick file for BOTN...\n",
+      "Creating pick file for BRU...\n",
+      "Creating pick file for BRUN...\n",
+      "Creating pick file for DDAL...\n",
+      "Creating pick file for DJK...\n",
+      "Creating pick file for DREK...\n",
+      "Creating pick file for DSAN...\n",
+      "Creating pick file for DYFE...\n",
+      "Creating pick file for DYJN...\n",
+      "Creating pick file for DYJS...\n",
+      "Creating pick file for DYN...\n",
+      "Creating pick file for DYNG...\n",
+      "Creating pick file for DYSA...\n",
+      "Creating pick file for EFJA...\n",
+      "Creating pick file for FJAL...\n",
+      "Creating pick file for FJAS...\n",
+      "Creating pick file for FLAE...\n",
+      "Creating pick file for FLAT...\n",
+      "Creating pick file for FLUR...\n",
+      "Creating pick file for FREF...\n",
+      "Creating pick file for FYDU...\n",
+      "Creating pick file for GODA...\n",
+      "Creating pick file for HALI...\n",
+      "Creating pick file for HELI...\n",
+      "Creating pick file for HERD...\n",
+      "Creating pick file for HETO...\n",
+      "Creating pick file for HOLR...\n",
+      "Creating pick file for HOLU...\n",
+      "Creating pick file for HOTT...\n",
+      "Creating pick file for HRIM...\n",
+      "Creating pick file for HRUR...\n",
+      "Creating pick file for HRUT...\n",
+      "Creating pick file for HVAF...\n",
+      "Creating pick file for JOAF...\n",
+      "Creating pick file for JONS...\n",
+      "Creating pick file for KATT...\n",
+      "Creating pick file for KLUR...\n",
+      "Creating pick file for KODA...\n",
+      "Creating pick file for KOLL...\n",
+      "Creating pick file for KRE...\n",
+      "Creating pick file for KREP...\n",
+      "Creating pick file for KVER...\n",
+      "Creating pick file for LIND...\n",
+      "Creating pick file for LOGR...\n",
+      "Creating pick file for LOKA...\n",
+      "Creating pick file for LOKT...\n",
+      "Creating pick file for MFLS...\n",
+      "Creating pick file for MIDF...\n",
+      "Creating pick file for MKO...\n",
+      "Creating pick file for MOFO...\n",
+      "Creating pick file for MVET...\n",
+      "Creating pick file for MYVO...\n",
+      "Creating pick file for NAUT...\n",
+      "Creating pick file for NOFL...\n",
+      "Creating pick file for NOHR...\n",
+      "Creating pick file for OLAF...\n",
+      "Creating pick file for OSKV...\n",
+      "Creating pick file for OSVA...\n",
+      "Creating pick file for RF02...\n",
+      "Creating pick file for RF03...\n",
+      "Creating pick file for RF04...\n",
+      "Creating pick file for RIFN...\n",
+      "Creating pick file for RIFR...\n",
+      "Creating pick file for RIMA...\n",
+      "Creating pick file for RODG...\n",
+      "Creating pick file for SBLA...\n",
+      "Creating pick file for SOFA...\n",
+      "Creating pick file for SOSU...\n",
+      "Creating pick file for SSUD...\n",
+      "Creating pick file for STAM...\n",
+      "Creating pick file for STJA...\n",
+      "Creating pick file for STOR...\n",
+      "Creating pick file for SVA...\n",
+      "Creating pick file for SVAD...\n",
+      "Creating pick file for TOHR...\n",
+      "Creating pick file for TOLI...\n",
+      "Creating pick file for TREB...\n",
+      "Creating pick file for UTYR...\n",
+      "Creating pick file for VADA...\n",
+      "Creating pick file for VEGG...\n",
+      "Creating pick file for VIBR...\n",
+      "Creating pick file for VIFE...\n",
+      "Creating pick file for VIKR...\n",
+      "Creating pick file for VIKS...\n",
+      "Creating pick file for VISA...\n",
+      "Creating pick file for VONK...\n",
+      "Creating pick file for VONS...\n",
+      "Generation of pick files complete.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# P phase picks\n",
+    "obspy2fmtomo(cat, stations, mkmodel, [\"P\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating pick file for ARNA...\n",
+      "Creating pick file for ASK...\n",
+      "Creating pick file for BJK...\n",
+      "Creating pick file for BLAF...\n",
+      "Creating pick file for BOTN...\n",
+      "Creating pick file for BRU...\n",
+      "Creating pick file for BRUN...\n",
+      "Creating pick file for DDAL...\n",
+      "Creating pick file for DJK...\n",
+      "Creating pick file for DREK...\n",
+      "Creating pick file for DSAN...\n",
+      "Creating pick file for DYFE...\n",
+      "Creating pick file for DYJN...\n",
+      "Creating pick file for DYJS...\n",
+      "Creating pick file for DYN...\n",
+      "Creating pick file for DYNG...\n",
+      "Creating pick file for DYSA...\n",
+      "Creating pick file for EFJA...\n",
+      "Creating pick file for FJAL...\n",
+      "Creating pick file for FJAS...\n",
+      "Creating pick file for FLAE...\n",
+      "Creating pick file for FLAT...\n",
+      "Creating pick file for FLUR...\n",
+      "Creating pick file for FREF...\n",
+      "Creating pick file for FYDU...\n",
+      "Creating pick file for GODA...\n",
+      "Creating pick file for HALI...\n",
+      "Creating pick file for HELI...\n",
+      "Creating pick file for HERD...\n",
+      "Creating pick file for HETO...\n",
+      "Creating pick file for HOLR...\n",
+      "Creating pick file for HOLU...\n",
+      "Creating pick file for HOTT...\n",
+      "Creating pick file for HRIM...\n",
+      "Creating pick file for HRUR...\n",
+      "Creating pick file for HRUT...\n",
+      "Creating pick file for HVAF...\n",
+      "Creating pick file for JOAF...\n",
+      "Creating pick file for JONS...\n",
+      "Creating pick file for KATT...\n",
+      "Creating pick file for KLUR...\n",
+      "Creating pick file for KODA...\n",
+      "Creating pick file for KOLL...\n",
+      "Creating pick file for KRE...\n",
+      "Creating pick file for KREP...\n",
+      "Creating pick file for KVER...\n",
+      "Creating pick file for LIND...\n",
+      "Creating pick file for LOGR...\n",
+      "Creating pick file for LOKA...\n",
+      "Creating pick file for LOKT...\n",
+      "Creating pick file for MFLS...\n",
+      "Creating pick file for MIDF...\n",
+      "Creating pick file for MKO...\n",
+      "Creating pick file for MOFO...\n",
+      "Creating pick file for MVET...\n",
+      "Creating pick file for MYVO...\n",
+      "Creating pick file for NAUT...\n",
+      "Creating pick file for NOFL...\n",
+      "Creating pick file for NOHR...\n",
+      "Creating pick file for OLAF...\n",
+      "Creating pick file for OSKV...\n",
+      "Creating pick file for OSVA...\n",
+      "Creating pick file for RF02...\n",
+      "Creating pick file for RF03...\n",
+      "Creating pick file for RF04...\n",
+      "Creating pick file for RIFN...\n",
+      "Creating pick file for RIFR...\n",
+      "Creating pick file for RIMA...\n",
+      "Creating pick file for RODG...\n",
+      "Creating pick file for SBLA...\n",
+      "Creating pick file for SOFA...\n",
+      "Creating pick file for SOSU...\n",
+      "Creating pick file for SSUD...\n",
+      "Creating pick file for STAM...\n",
+      "Creating pick file for STJA...\n",
+      "Creating pick file for STOR...\n",
+      "Creating pick file for SVA...\n",
+      "Creating pick file for SVAD...\n",
+      "Creating pick file for TOHR...\n",
+      "Creating pick file for TOLI...\n",
+      "Creating pick file for TREB...\n",
+      "Creating pick file for UTYR...\n",
+      "Creating pick file for VADA...\n",
+      "Creating pick file for VEGG...\n",
+      "Creating pick file for VIBR...\n",
+      "Creating pick file for VIFE...\n",
+      "Creating pick file for VIKR...\n",
+      "Creating pick file for VIKS...\n",
+      "Creating pick file for VISA...\n",
+      "Creating pick file for VONK...\n",
+      "Creating pick file for VONS...\n",
+      "Generation of pick files complete.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# S phase picks\n",
+    "obspy2fmtomo(cat, stations, mkmodel, [\"S\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.8"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Create the input pick files required to run FMTomo from an Obspy Catalog
object. The notebook also contains examples for creating such a Catalog
from .hyp (output of NonLinLoc) files, or the output of a QuakeMigrate
run.

Also add some short notes on preparing an FMTomo run.